### PR TITLE
DigitalOcean object storage support - fixed area code error - refactor some code

### DIFF
--- a/Console/Command/ConfigListCommand.php
+++ b/Console/Command/ConfigListCommand.php
@@ -28,7 +28,14 @@ class ConfigListCommand extends \Symfony\Component\Console\Command\Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->state->setAreaCode('adminhtml');
+        try {
+            $this->state->setAreaCode('adminhtml');
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            // intentionally left empty
+        }
+
+        echo(sprintf("[Debug] App Area: %s\n", $this->state->getAreaCode())); // Required to avoid "area code not set" error
+
         $config = $this->configFactory->create();
         $output->writeln('Here are your AWS credentials.');
         $output->writeln('');
@@ -36,5 +43,6 @@ class ConfigListCommand extends \Symfony\Component\Console\Command\Command
         $output->writeln(sprintf('Secret Access Key: %s', $config->getConfigDataValue('thai_s3/general/secret_key')));
         $output->writeln(sprintf('Bucket:            %s', $config->getConfigDataValue('thai_s3/general/bucket')));
         $output->writeln(sprintf('Region:            %s', $config->getConfigDataValue('thai_s3/general/region')));
+        $output->writeln(sprintf('Region:            %s', $config->getConfigDataValue('thai_s3/general/endpoint')));
     }
 }

--- a/Console/Command/ConfigListCommand.php
+++ b/Console/Command/ConfigListCommand.php
@@ -43,6 +43,6 @@ class ConfigListCommand extends \Symfony\Component\Console\Command\Command
         $output->writeln(sprintf('Secret Access Key: %s', $config->getConfigDataValue('thai_s3/general/secret_key')));
         $output->writeln(sprintf('Bucket:            %s', $config->getConfigDataValue('thai_s3/general/bucket')));
         $output->writeln(sprintf('Region:            %s', $config->getConfigDataValue('thai_s3/general/region')));
-        $output->writeln(sprintf('Region:            %s', $config->getConfigDataValue('thai_s3/general/endpoint')));
+        $output->writeln(sprintf('Endpoint:          %s', $config->getConfigDataValue('thai_s3/general/endpoint')));
     }
 }

--- a/Console/Command/StorageDisableCommand.php
+++ b/Console/Command/StorageDisableCommand.php
@@ -42,6 +42,14 @@ class StorageDisableCommand extends \Symfony\Component\Console\Command\Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        try {
+            $this->state->setAreaCode('adminhtml');
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            // intentionally left empty
+        }
+
+        echo(sprintf("[Debug] App Area: %s\n", $this->state->getAreaCode())); // Required to avoid "area code not set" error
+
         $errors = $this->validate($input);
         if ($errors) {
             $output->writeln('<error>' . implode('</error>' . PHP_EOL .  '<error>', $errors) . '</error>');
@@ -49,14 +57,20 @@ class StorageDisableCommand extends \Symfony\Component\Console\Command\Command
         }
 
         try {
-            $this->client = new \Aws\S3\S3Client([
+            $options = [
                 'version' => 'latest',
                 'region' => $this->helper->getRegion(),
                 'credentials' => [
                     'key' => $this->helper->getAccessKey(),
                     'secret' => $this->helper->getSecretKey()
                 ]
-            ]);
+            ];
+
+            if ( ! empty($this->helper->getEndpoint())) {
+                $options['endpoint'] = $this->helper->getEndpoint();
+            }
+
+            $this->client = new \Aws\S3\S3Client($options);
         } catch (\Exception $e) {
             $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
             return;
@@ -74,7 +88,6 @@ class StorageDisableCommand extends \Symfony\Component\Console\Command\Command
 
         $output->writeln('Updating configuration to use the local filesystem.');
 
-        $this->state->setAreaCode('adminhtml');
         $config = $this->configFactory->create();
         $config->setDataByPath('system/media_storage_configuration/media_storage', \Magento\MediaStorage\Model\File\Storage::STORAGE_MEDIA_FILE_SYSTEM);
         $config->save();

--- a/Console/Command/StorageExportCommand.php
+++ b/Console/Command/StorageExportCommand.php
@@ -42,21 +42,35 @@ class StorageExportCommand extends \Symfony\Component\Console\Command\Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        try {
+            $this->state->setAreaCode('adminhtml');
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            // intentionally left empty
+        }
+
+        echo(sprintf("[Debug] App Area: %s\n", $this->state->getAreaCode())); // Required to avoid "area code not set" error
+
         $errors = $this->validate($input);
         if ($errors) {
             $output->writeln('<error>' . implode('</error>' . PHP_EOL .  '<error>', $errors) . '</error>');
             return;
         }
 
+        $options = [
+            'version' => 'latest',
+            'region' => $this->helper->getRegion(),
+            'credentials' => [
+                'key' => $this->helper->getAccessKey(),
+                'secret' => $this->helper->getSecretKey()
+            ]
+        ];
+
+        if ( ! empty($this->helper->getEndpoint())) {
+            $options['endpoint'] = $this->helper->getEndpoint();
+        }
+
         try {
-            $this->client = new \Aws\S3\S3Client([
-                'version' => 'latest',
-                'region' => $this->helper->getRegion(),
-                'credentials' => [
-                    'key' => $this->helper->getAccessKey(),
-                    'secret' => $this->helper->getSecretKey()
-                ]
-            ]);
+            $this->client = new \Aws\S3\S3Client($options);
         } catch (\Exception $e) {
             $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
             return;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -36,6 +36,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         return $this->scopeConfig->getValue('thai_s3/general/region');
     }
 
+    public function getEndpoint()
+    {
+        return $this->scopeConfig->getValue('thai_s3/general/endpoint');
+    }
+
     public function getBucket()
     {
         return $this->scopeConfig->getValue('thai_s3/general/bucket');

--- a/Helper/S3.php
+++ b/Helper/S3.php
@@ -90,6 +90,10 @@ class S3
                 'value' => 'us-west-2',
                 'label' => 'US West (Oregon)'
             ],
+            [
+                'value' => 'ams3',
+                'label' => 'EU (Amsterdam)'
+            ]
         ];
     }
 }

--- a/Model/MediaStorage/File/Storage/S3.php
+++ b/Model/MediaStorage/File/Storage/S3.php
@@ -56,14 +56,20 @@ class S3 extends DataObject
         $this->storageHelper = $storageHelper;
         $this->logger = $logger;
 
-        $this->client = new \Aws\S3\S3Client([
+        $options = [
             'version' => 'latest',
             'region' => $this->helper->getRegion(),
             'credentials' => [
                 'key' => $this->helper->getAccessKey(),
                 'secret' => $this->helper->getSecretKey()
             ]
-        ]);
+        ];
+
+        if ( ! empty($this->helper->getEndpoint())) {
+            $options['endpoint'] = $this->helper->getEndpoint();
+        }
+
+        $this->client = new \Aws\S3\S3Client($options);
     }
 
     /**


### PR DESCRIPTION
1. Added endpoint to module to configuration. This is required because the url for digitaloacean is different.(https://[bucket].[region].digitaloaceanspaces.com)
2. Fixed bug in module, area code is not set. Added try catch.
3. Refactored some options to set options